### PR TITLE
Enable comments in taglibs

### DIFF
--- a/app/models/owned_model.rb
+++ b/app/models/owned_model.rb
@@ -4,8 +4,7 @@ OwnedModel = classy_module do
   
   
   def create_permitted?
-    # acting_user.signed_up? && user == acting_user
-    acting_user.signed_up?
+    acting_user.signed_up? && (user == acting_user || new_record?)
   end
 
   def update_permitted?

--- a/app/models/owned_model.rb
+++ b/app/models/owned_model.rb
@@ -4,7 +4,8 @@ OwnedModel = classy_module do
   
   
   def create_permitted?
-    acting_user.signed_up? && user == acting_user
+    # acting_user.signed_up? && user == acting_user
+    acting_user.signed_up?
   end
 
   def update_permitted?

--- a/app/views/api_tag_defs/show.dryml
+++ b/app/views/api_tag_defs/show.dryml
@@ -51,8 +51,11 @@
 
       <section class="add-to-collection" if="&can_create?(@api_tag_def.comments)">
         <h3 class="add-form-heading">Add a Comment</h3>
-        <form with="&@api_tag_def.comments.new" owner="api_tag_def" method="post" without-cancel>
-          <field-list: skip="api_tag_def, markdown"/>
+        <form with="&@api_tag_def.comments.new" owner="api_tag_def" method="post" action="/api_tag_defs/#{this.id}/comments" without-cancel>
+          <field-list: skip="api_tag_def, markdown, user"/>
+          <before-submit:>
+            <input type="hidden" name="api_tag_comment[user_id]" value="&current_user.id"/>
+          </before-submit:>
           <submit: label="Add"/>
         </form>
       </section>


### PR DESCRIPTION
I modified the permissions in owned_model.rb so new records are taken into account.

After that, I also had to modify the form a bit: 
- Remove the user select and make a hidden-field with its id
- Modify the action URL so it uses the id of the taglib. I think this has to do with the customised URLs in the taglibs (without ID).

And now it works :)
